### PR TITLE
Use the current thread runtime for Tokio tasks

### DIFF
--- a/client/src/builder.rs
+++ b/client/src/builder.rs
@@ -236,6 +236,13 @@ impl ClientBuilder {
         self.config.session_timeout = session_timeout;
         self
     }
+
+    /// Configures the client to use a single-threaded executor. The default executor uses a
+    /// thread pool with a worker thread for each CPU core available on the system.
+    pub fn single_threaded_executor(mut self) -> Self {
+        self.config.single_threaded_executor = true;
+        self
+    }
 }
 
 #[test]
@@ -257,6 +264,7 @@ fn client_builder() {
         .session_retry_interval(1234)
         .session_retry_limit(999)
         .session_timeout(777)
+        .single_threaded_executor()
         // TODO user tokens, endpoints
         ;
 
@@ -278,4 +286,5 @@ fn client_builder() {
     assert_eq!(c.session_retry_interval, 1234);
     assert_eq!(c.session_retry_limit, 999);
     assert_eq!(c.session_timeout, 777);
+    assert_eq!(c.single_threaded_executor, true);
 }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -389,6 +389,7 @@ impl Client {
                 self.certificate_store.clone(),
                 session_info,
                 self.session_retry_policy.clone(),
+                self.config.single_threaded_executor,
             )));
             Ok(session)
         }
@@ -462,6 +463,7 @@ impl Client {
                 self.certificate_store.clone(),
                 session_info,
                 self.session_retry_policy.clone(),
+                self.config.single_threaded_executor,
             );
             session.connect()?;
             let result = session.get_endpoints()?;

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -163,6 +163,9 @@ pub struct ClientConfig {
     pub session_retry_interval: u32,
     /// Session timeout period in milliseconds
     pub session_timeout: u32,
+    /// Use a single-threaded executor. The default executor uses a thread pool with a worker
+    /// thread for each CPU core available on the system.
+    pub single_threaded_executor: bool,
 }
 
 impl Config for ClientConfig {
@@ -290,6 +293,7 @@ impl ClientConfig {
             session_retry_limit: SessionRetryPolicy::DEFAULT_RETRY_LIMIT as i32,
             session_retry_interval: SessionRetryPolicy::DEFAULT_RETRY_INTERVAL_MS,
             session_timeout: 0,
+            single_threaded_executor: false,
         }
     }
 }

--- a/samples/client.conf
+++ b/samples/client.conf
@@ -40,3 +40,4 @@ endpoints:
 session_retry_limit: 10
 session_retry_interval: 10000
 session_timeout: 0
+single_threaded_executor: false

--- a/samples/demo-server/src/main.rs
+++ b/samples/demo-server/src/main.rs
@@ -82,6 +82,7 @@ fn start_http_server(server: &Server) {
     let server_state = server.server_state();
     let connections = server.connections();
     let metrics = server.server_metrics();
+    let single_threaded_executor = server.single_threaded_executor();
     // The index.html is in a path relative to the working dir.
     let _ = http::run_http_server(
         "127.0.0.1:8585",
@@ -89,5 +90,6 @@ fn start_http_server(server: &Server) {
         server_state,
         connections,
         metrics,
+        single_threaded_executor,
     );
 }

--- a/samples/server.conf
+++ b/samples/server.conf
@@ -154,3 +154,4 @@ endpoints:
       - ANONYMOUS
       - sample_password_user
       - sample_x509_user
+single_threaded_executor: false

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -351,4 +351,11 @@ impl ServerBuilder {
         self.config.limits.clients_can_modify_address_space = true;
         self
     }
+
+    /// Configures the server to use a single-threaded executor. The default executor uses a
+    /// thread pool with a worker thread for each CPU core available on the system.
+    pub fn single_threaded_executor(mut self) -> Self {
+        self.config.single_threaded_executor = true;
+        self
+    }
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -517,6 +517,9 @@ pub struct ServerConfig {
     pub default_endpoint: Option<String>,
     /// Endpoints supported by the server
     pub endpoints: BTreeMap<String, ServerEndpoint>,
+    /// Use a single-threaded executor. The default executor uses a thread pool with a worker
+    /// thread for each CPU core available on the system.
+    pub single_threaded_executor: bool,
 }
 
 impl Config for ServerConfig {
@@ -621,6 +624,7 @@ impl Default for ServerConfig {
             discovery_urls: Vec::new(),
             default_endpoint: None,
             endpoints: BTreeMap::new(),
+            single_threaded_executor: false,
         }
     }
 }
@@ -671,6 +675,7 @@ impl ServerConfig {
             discovery_urls,
             default_endpoint: None,
             endpoints,
+            single_threaded_executor: false,
         }
     }
 

--- a/server/src/http/mod.rs
+++ b/server/src/http/mod.rs
@@ -97,6 +97,7 @@ pub fn run_http_server(
     server_state: Arc<RwLock<ServerState>>,
     connections: Arc<RwLock<Connections>>,
     server_metrics: Arc<RwLock<ServerMetrics>>,
+    single_threaded_executor: bool,
 ) {
     let address = String::from(address);
     let base_path = PathBuf::from(content_path);
@@ -146,9 +147,16 @@ pub fn run_http_server(
 
     // Spawn a tokio task to monitor for quit and to shutdown the http server
     thread::spawn(move || {
-        tokio::run(quit_task.map(move |_| {
-            info!("HTTP server will be stopped");
-            let _ = addr.send(server::StopServer { graceful: false });
-        }));
+        if !single_threaded_executor {
+            tokio::runtime::run(quit_task.map(move |_| {
+                info!("HTTP server will be stopped");
+                let _ = addr.send(server::StopServer { graceful: false });
+            }));
+        } else {
+            tokio::runtime::current_thread::run(quit_task.map(move |_| {
+                info!("HTTP server will be stopped");
+                let _ = addr.send(server::StopServer { graceful: false });
+            }));
+        }
     });
 }


### PR DESCRIPTION
The default runtime is a threaded runtime which spawns a background
thread running a reactor instance and then creates a threadpool (with
the number of threads equal the the number of available CPU cores).

Now this creates a lot of threads, especially when multiple runtimes
are started, like in the client package. And while having a lot of
threads should not be a problem, Tokio needs to be able to communicate
between these threads so it (on Linux) creates unix pipes for that.
On an 16 core machine this resulted in around 144 handles per client.

On our system and the way we use multiple clients in our application
this caused us to hit the 1024 default open file handle limit. In most
cases that limit can easily be updated, but in our case that isn't an
option/solution. So I went looking at the code to see if there was an
"easy" fix and it seems there is one... As all the runtimes that are
created are actually created inside new dedicated threads, it seems
that using that single thread for the new runtime is a more efficient
and solution which seems to be inline with how things were intended to
work.

I made the required changes in this PR and hope this is indeed inline
with how you inteded to use Tokio. I excluded the runtime in the main
`run_server` function as I can imagine in that particular case it could
make sense to use a threaded runtime (now sure, can of cause make the
change for this one as well if you want).